### PR TITLE
Fix crashing on startup on iOS

### DIFF
--- a/ios/Classes/SwiftConnectycubeFlutterCallKitPlugin.swift
+++ b/ios/Classes/SwiftConnectycubeFlutterCallKitPlugin.swift
@@ -73,8 +73,8 @@ public class SwiftConnectycubeFlutterCallKitPlugin: NSObject, FlutterPlugin {
             result(voipToken)
         }
         else if(call.method == "updateConfig"){
-            let ringtone = arguments["ringtone"] as! String
-            let icon = arguments["icon"] as! String
+            let ringtone = arguments["ringtone"] as? String
+            let icon = arguments["icon"] as? String
             CallKitController.updateConfig(ringtone: ringtone, icon: icon)
             
             result(true)


### PR DESCRIPTION
`ringtone` and `icon` are marked as optional on flutter side but are marked as required on iOS side, leading to the app crashing immediately on startup if we don't pass those two arguments on `ConnectycubeFlutterCallKit.instance.init()` function.

Resolve #44 